### PR TITLE
Update max-width in media query

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -36,7 +36,7 @@ html {
   background-repeat: no-repeat;
 }
 
-@media screen and (max-width: 992px) {
+@media screen and (max-width: 1366px) {
   .section__heading {
     background-attachment: scroll;
   }


### PR DESCRIPTION
This pull request updates the max-width value in the media query from 992px to 1366px. This change ensures that the section__heading background-attachment property is applied correctly on screens with a width of 1366px or less.